### PR TITLE
Set default export of amazonPaapi

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,4 +75,6 @@ const getPartnerType = partnerType =>  new Promise ((resolve, reject) => {
 
 const isUndefined = value => typeof value === 'undefined'; 
 
-module.exports = { GetItems, GetBrowseNodes, GetVariations, SearchItems };
+const amazonPaapi = { GetItems, GetBrowseNodes, GetVariations, SearchItems };
+// Allow use of default import syntax in TypeScript
+module.exports.default = amazonPaapi;


### PR DESCRIPTION
I have wrapped functions in a const amazonPaapi so you can use import amazonPaapi from 'amazon-paapi'.

If you are using require:

const amazonPaapi = require('amazonPaapi').default;

**IMPORTANT! Change documentation about import**