### PR TITLE
Update version to add marketplace belgium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Change Log
+    1.0.8 August 30, 2024
+
+- Update marketplace list. Added Belgium.
+
     1.0.7 August 30, 2022
 
 - Add querystring module from main package.json. legacy dependency used by the SDK.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-paapi",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Amazon Associate Product Advertising API for NodeJs. A PAAPI 5.0 Extension.",
   "main": "app.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amazon-paapi",
+  "name": "amazon-paapi-laurens",
   "version": "1.0.8",
   "description": "Amazon Associate Product Advertising API for NodeJs. A PAAPI 5.0 Extension.",
   "main": "app.js",


### PR DESCRIPTION
The added marketplace value of Belgium is not in the latest release. So I updated the version.